### PR TITLE
Add expression interpreter service and React interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,56 @@
-# expressionEvaluate
+# Interpretador de Expressões (Infix ➜ Postfix ➜ Resultado)
+
+Este projeto demonstra um fluxo completo de interpretação de expressões matemáticas:
+
+1. **Tokenização léxica** – quebra a expressão em tokens (números, operadores e parênteses).
+2. **Análise sintática estilo *Shunting Yard*** – converte a forma infixa para pós-fixa (RPN) usando pilhas e filas.
+3. **Avaliação da RPN** – executa a expressão pós-fixa, exibindo cada passo de manipulação da pilha.
+
+A interface React permite que o usuário forneça uma linha de código (a expressão matemática) e visualize cada estágio do processo de interpretação.
+
+## Estrutura
+
+```
+backend/   → servidor Node.js sem dependências externas
+frontend/  → interface React independente, carregada via CDN
+```
+
+## Executando o backend
+
+```bash
+cd backend
+node server.js
+```
+
+O servidor ficará disponível em `http://localhost:3001` com o endpoint `POST /evaluate`.
+
+### Exemplo de requisição
+
+```bash
+curl -X POST http://localhost:3001/evaluate \
+  -H "Content-Type: application/json" \
+  -d '{"expression": "3 + 4 * 2 / (1 - 5) ^ 2 ^ 3"}'
+```
+
+## Executando o frontend
+
+Como o frontend é um arquivo estático, você pode servi-lo com qualquer servidor HTTP simples. Exemplos:
+
+```bash
+cd frontend
+python -m http.server 8080
+# em seguida abra http://localhost:8080 no navegador
+```
+
+A interface se comunicará com o backend em `http://localhost:3001/evaluate` e exibirá:
+
+- Tokens identificados na expressão
+- Passos detalhados do algoritmo Shunting Yard (fila de saída e pilha de operadores)
+- Sequência de avaliação pós-fixa com o estado da pilha após cada ação
+- Resultado final da expressão
+
+## Observações
+
+- Suporta operadores `+`, `-`, `*`, `/`, `^`, parênteses e negativo unário.
+- Em caso de erros (símbolos desconhecidos, parênteses desbalanceados, etc.), o backend retorna mensagens descritivas.
+- O projeto foi pensado para demonstrar o raciocínio *compiler-like* de forma didática e transparente.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "Servidor de avaliação de expressões infix -> postfix -> resultado",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [
+    "compiler",
+    "expression",
+    "postfix"
+  ],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,262 @@
+const http = require('http');
+const url = require('url');
+
+const PORT = process.env.PORT || 3001;
+
+function tokenize(expression) {
+  const tokens = [];
+  const regex = /\s*([0-9]*\.?[0-9]+|[()+\-*/^])/g;
+  let match;
+  let index = 0;
+  while ((match = regex.exec(expression)) !== null) {
+    const [lexeme, value] = match;
+    const start = match.index + (lexeme.length - value.length);
+    if (start > index) {
+      const skipped = expression.slice(index, start);
+      if (!/^\s*$/.test(skipped)) {
+        throw new Error(`Símbolo desconhecido próximo a '${skipped}'.`);
+      }
+    }
+    index = match.index + lexeme.length;
+
+    if (/^\d/.test(value)) {
+      tokens.push({ type: 'number', value: parseFloat(value), raw: value });
+    } else if (value === '(') {
+      tokens.push({ type: 'lparen', value });
+    } else if (value === ')') {
+      tokens.push({ type: 'rparen', value });
+    } else {
+      tokens.push({ type: 'operator', value });
+    }
+  }
+
+  if (index < expression.length) {
+    const remaining = expression.slice(index);
+    if (!/^\s*$/.test(remaining)) {
+      throw new Error(`Símbolo desconhecido próximo a '${remaining}'.`);
+    }
+  }
+
+  return tokens;
+}
+
+const PRECEDENCE = {
+  '+': { precedence: 2, associativity: 'left', arity: 2 },
+  '-': { precedence: 2, associativity: 'left', arity: 2 },
+  '*': { precedence: 3, associativity: 'left', arity: 2 },
+  '/': { precedence: 3, associativity: 'left', arity: 2 },
+  '^': { precedence: 4, associativity: 'right', arity: 2 },
+  'u-': { precedence: 5, associativity: 'right', arity: 1 }
+};
+
+function isUnaryMinus(tokens, index) {
+  const token = tokens[index];
+  if (token.type !== 'operator' || token.value !== '-') return false;
+  if (index === 0) return true;
+  const prev = tokens[index - 1];
+  return prev.type === 'operator' || prev.type === 'lparen';
+}
+
+function toPostfix(tokens) {
+  const output = [];
+  const operatorStack = [];
+  const steps = [];
+
+  tokens.forEach((token, index) => {
+    let processedToken = token;
+    if (isUnaryMinus(tokens, index)) {
+      processedToken = { ...token, value: 'u-' };
+    }
+
+    if (processedToken.type === 'number') {
+      output.push(processedToken);
+    } else if (processedToken.type === 'operator') {
+      const currentInfo = PRECEDENCE[processedToken.value];
+      if (!currentInfo) {
+        throw new Error(`Operador desconhecido '${processedToken.value}'.`);
+      }
+      while (operatorStack.length > 0) {
+        const top = operatorStack[operatorStack.length - 1];
+        if (top.type !== 'operator') break;
+        const topInfo = PRECEDENCE[top.value];
+        const shouldPop = (currentInfo.associativity === 'left' && currentInfo.precedence <= topInfo.precedence) ||
+          (currentInfo.associativity === 'right' && currentInfo.precedence < topInfo.precedence);
+        if (!shouldPop) break;
+        output.push(operatorStack.pop());
+      }
+      operatorStack.push(processedToken);
+    } else if (processedToken.type === 'lparen') {
+      operatorStack.push(processedToken);
+    } else if (processedToken.type === 'rparen') {
+      let found = false;
+      while (operatorStack.length > 0) {
+        const op = operatorStack.pop();
+        if (op.type === 'lparen') {
+          found = true;
+          break;
+        }
+        output.push(op);
+      }
+      if (!found) {
+        throw new Error('Parênteses desbalanceados.');
+      }
+    }
+
+    steps.push({
+      token: processedToken,
+      output: output.map(mapTokenForStep),
+      operatorStack: operatorStack.map(mapTokenForStep)
+    });
+  });
+
+  while (operatorStack.length > 0) {
+    const op = operatorStack.pop();
+    if (op.type === 'lparen' || op.type === 'rparen') {
+      throw new Error('Parênteses desbalanceados.');
+    }
+    output.push(op);
+    steps.push({
+      token: { type: 'operator', value: '(desempilhar)' },
+      output: output.map(mapTokenForStep),
+      operatorStack: operatorStack.map(mapTokenForStep)
+    });
+  }
+
+  return { postfix: output, steps };
+}
+
+function mapTokenForStep(token) {
+  if (!token) return token;
+  if (token.type === 'number') return token.raw ?? token.value.toString();
+  return token.value;
+}
+
+function evaluatePostfix(postfix) {
+  const stack = [];
+  const steps = [];
+
+  postfix.forEach((token) => {
+    if (token.type === 'number') {
+      stack.push(token.value);
+      steps.push({ action: `Empilha número ${token.value}`, stack: [...stack] });
+    } else if (token.type === 'operator') {
+      const info = PRECEDENCE[token.value];
+      if (!info) {
+        throw new Error(`Operador desconhecido '${token.value}'.`);
+      }
+      if (info.arity === 1) {
+        if (stack.length < 1) {
+          throw new Error('Expressão inválida: operandos insuficientes.');
+        }
+        const a = stack.pop();
+        const result = -a;
+        stack.push(result);
+        steps.push({
+          action: `Aplica negativo unário em ${a}`,
+          stack: [...stack]
+        });
+      } else {
+        if (stack.length < 2) {
+          throw new Error('Expressão inválida: operandos insuficientes.');
+        }
+        const b = stack.pop();
+        const a = stack.pop();
+        let result;
+        switch (token.value) {
+          case '+':
+            result = a + b;
+            break;
+          case '-':
+            result = a - b;
+            break;
+          case '*':
+            result = a * b;
+            break;
+          case '/':
+            result = a / b;
+            break;
+          case '^':
+            result = Math.pow(a, b);
+            break;
+          default:
+            throw new Error(`Operador desconhecido '${token.value}'.`);
+        }
+        stack.push(result);
+        steps.push({
+          action: `Aplica ${token.value} em ${a} e ${b}`,
+          stack: [...stack]
+        });
+      }
+    }
+  });
+
+  if (stack.length !== 1) {
+    throw new Error('Expressão inválida: sobrou mais de um valor na pilha.');
+  }
+
+  return { result: stack[0], steps };
+}
+
+function handleEvaluate(req, res, body) {
+  try {
+    const data = JSON.parse(body || '{}');
+    const expression = data.expression;
+    if (typeof expression !== 'string' || expression.trim() === '') {
+      throw new Error('Informe uma expressão válida.');
+    }
+
+    const tokens = tokenize(expression);
+    const { postfix, steps: parseSteps } = toPostfix(tokens);
+    const evaluation = evaluatePostfix(postfix);
+
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*'
+    });
+    res.end(JSON.stringify({
+      expression,
+      tokens,
+      postfix: postfix.map(mapTokenForStep),
+      parseSteps,
+      evaluationSteps: evaluation.steps,
+      result: evaluation.result
+    }));
+  } catch (error) {
+    res.writeHead(400, {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*'
+    });
+    res.end(JSON.stringify({ message: error.message }));
+  }
+}
+
+const server = http.createServer((req, res) => {
+  const parsedUrl = url.parse(req.url, true);
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type'
+    });
+    res.end();
+    return;
+  }
+
+  if (req.method === 'POST' && parsedUrl.pathname === '/evaluate') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => handleEvaluate(req, res, body));
+    return;
+  }
+
+  res.writeHead(404, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*'
+  });
+  res.end(JSON.stringify({ message: 'Rota não encontrada' }));
+});
+
+server.listen(PORT, () => {
+  console.log(`Servidor de avaliação ouvindo na porta ${PORT}`);
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Interpretador de Expressões</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        font-family: 'Fira Code', monospace;
+        margin: 0;
+        padding: 0;
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+      .app {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 2rem;
+      }
+      h1 {
+        margin-bottom: 1rem;
+      }
+      form {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        margin-bottom: 1.5rem;
+        background: rgba(15, 23, 42, 0.6);
+        padding: 1.5rem;
+        border-radius: 12px;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+      }
+      input[type="text"] {
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        background: rgba(30, 41, 59, 0.8);
+        color: inherit;
+        font-size: 1rem;
+      }
+      button {
+        align-self: flex-start;
+        padding: 0.75rem 1.5rem;
+        border: none;
+        border-radius: 8px;
+        background: #38bdf8;
+        color: #0f172a;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+      }
+      button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 25px rgba(56, 189, 248, 0.2);
+      }
+      .panel {
+        background: rgba(15, 23, 42, 0.6);
+        padding: 1.5rem;
+        border-radius: 12px;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        margin-bottom: 1.5rem;
+      }
+      .panel h2 {
+        margin-top: 0;
+        margin-bottom: 0.75rem;
+        color: #38bdf8;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 0.75rem;
+      }
+      th,
+      td {
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      code {
+        background: rgba(30, 41, 59, 0.9);
+        padding: 0.25rem 0.5rem;
+        border-radius: 6px;
+      }
+      .steps {
+        display: grid;
+        gap: 0.75rem;
+      }
+      .step {
+        border-radius: 8px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        padding: 0.75rem;
+        background: rgba(30, 41, 59, 0.65);
+      }
+      .error {
+        background: rgba(248, 113, 113, 0.12);
+        border: 1px solid rgba(248, 113, 113, 0.35);
+        color: #fecaca;
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        margin-bottom: 1rem;
+      }
+      footer {
+        margin-top: 2rem;
+        text-align: center;
+        color: rgba(148, 163, 184, 0.6);
+        font-size: 0.9rem;
+      }
+    </style>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel">
+      const { useState } = React;
+
+      function ExpressionInterpreter() {
+        const [expression, setExpression] = useState('3 + 4 * 2 / (1 - 5) ^ 2 ^ 3');
+        const [result, setResult] = useState(null);
+        const [loading, setLoading] = useState(false);
+        const [error, setError] = useState(null);
+
+        const handleSubmit = async (event) => {
+          event.preventDefault();
+          setLoading(true);
+          setError(null);
+          try {
+            const response = await fetch('http://localhost:3001/evaluate', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({ expression }),
+            });
+            const data = await response.json();
+            if (!response.ok) {
+              throw new Error(data.message || 'Erro ao avaliar expressão');
+            }
+            setResult(data);
+          } catch (err) {
+            setResult(null);
+            setError(err.message);
+          } finally {
+            setLoading(false);
+          }
+        };
+
+        return (
+          <div className="app">
+            <h1>Interpretador de Expressões Matemáticas</h1>
+            <p>
+              Digite uma expressão infixa para ver o processo de tokenização, conversão para
+              pós-fixa (RPN) e a avaliação passo a passo utilizando pilhas e filas.
+            </p>
+            <form onSubmit={handleSubmit}>
+              <label htmlFor="expression">Expressão</label>
+              <input
+                id="expression"
+                type="text"
+                value={expression}
+                onChange={(event) => setExpression(event.target.value)}
+                placeholder="Ex: (2 + 3) * 4"
+              />
+              <button type="submit" disabled={loading}>
+                {loading ? 'Interpretando…' : 'Interpretar'}
+              </button>
+            </form>
+            {error && <div className="error">{error}</div>}
+            {result && (
+              <div className="panel">
+                <h2>Visão Geral</h2>
+                <p>
+                  <strong>Expressão normalizada:</strong> <code>{result.expression}</code>
+                </p>
+                <p>
+                  <strong>Resultado final:</strong> <code>{result.result}</code>
+                </p>
+              </div>
+            )}
+            {result && (
+              <div className="panel">
+                <h2>Tokens</h2>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Lexema</th>
+                      <th>Tipo</th>
+                      <th>Valor</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {result.tokens.map((token, index) => (
+                      <tr key={index}>
+                        <td><code>{token.raw ?? token.value}</code></td>
+                        <td>{token.type}</td>
+                        <td>{token.value}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            {result && (
+              <div className="panel">
+                <h2>Fila Pós-fixa</h2>
+                <p>
+                  <code>{result.postfix.join(' ')}</code>
+                </p>
+                <div className="steps">
+                  <h3>Passos do Shunting Yard</h3>
+                  {result.parseSteps.map((step, index) => (
+                    <div className="step" key={index}>
+                      <div><strong>Token lido:</strong> <code>{step.token.value ?? step.token}</code></div>
+                      <div><strong>Fila de saída:</strong> <code>{step.output.join(' ')}</code></div>
+                      <div><strong>Pilha de operadores:</strong> <code>{step.operatorStack.join(' ') || '∅'}</code></div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {result && (
+              <div className="panel">
+                <h2>Execução Pós-fixa</h2>
+                <div className="steps">
+                  {result.evaluationSteps.map((step, index) => (
+                    <div className="step" key={index}>
+                      <div><strong>Ação:</strong> {step.action}</div>
+                      <div><strong>Pilha:</strong> <code>{step.stack.join(' ')}</code></div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            <footer>
+              Construído com React no front-end e um interpretador em Node.js inspirado em compiladores
+              tradicionais.
+            </footer>
+          </div>
+        );
+      }
+
+      const root = ReactDOM.createRoot(document.getElementById('root'));
+      root.render(<ExpressionInterpreter />);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- implement a standalone Node.js service that tokenizes, converges to postfix and evaluates expressions using pilhas e filas
- expose a POST /evaluate endpoint that retorna tokens, passos do shunting yard e avaliação passo a passo
- create a React single-page interface to consumir o serviço e exibir todos os estágios da interpretação
- documentar execução de backend e frontend no README

## Testing
- `curl -s -X POST http://localhost:3001/evaluate -H "Content-Type: application/json" -d '{"expression":"3 + 4 * 2"}'`


------
https://chatgpt.com/codex/tasks/task_e_68d160f832f08330a65fa9e303cfc2fe